### PR TITLE
Fixing query range and reverting batch size

### DIFF
--- a/loadclient/config.go
+++ b/loadclient/config.go
@@ -13,6 +13,7 @@ type Options struct {
 	DestinationAPIURL    string
 	QueryFile            string
 	Queries              []string
+	QueryRange           string
 	Loki                 Loki
 }
 

--- a/loadclient/generate.go
+++ b/loadclient/generate.go
@@ -281,7 +281,7 @@ func initPromtailClient(apiURL string, tenantID string) (promtail.Client, error)
 	logger := kitlog.NewLogfmtLogger(os.Stdout)
 	promtailClient, err := promtail.New(promtail.Config{
 		BatchWait: 0,
-		BatchSize: 1000000,
+		BatchSize: 1000,
 		Timeout:   time.Second * 30,
 		BackoffConfig: util.BackoffConfig{
 			MinBackoff: time.Second * 1,

--- a/loadclient/query.go
+++ b/loadclient/query.go
@@ -18,8 +18,18 @@ import (
 
 type logQuerier struct {
 	runner
-	queryFrom func(query string, lineCount int64) error
-	queries   []string
+	queryFrom  func(query string, lineCount int64) error
+	queries    []string
+	queryRange time.Duration
+}
+
+func (q *logQuerier) initQueryRange() {
+	dur, err := time.ParseDuration(opt.QueryRange)
+	if err != nil {
+		panic(err)
+	}
+
+	q.queryRange = dur * -1
 }
 
 func (q *logQuerier) initQueryDestination() {
@@ -46,7 +56,7 @@ func (q *logQuerier) initQueryDestination() {
 func (q *logQuerier) queryLoki(query string, count int64) error {
 	log.Infof("query: %v\n", query)
 
-	resp, err := q.lokiLogCLIClient.QueryRange(query, 4000, time.Now().Add(-24*time.Hour), time.Now(), logproto.FORWARD, 0, 0, false)
+	resp, err := q.lokiLogCLIClient.QueryRange(query, 4000, time.Now().Add(q.queryRange), time.Now(), logproto.FORWARD, 0, 0, false)
 	if err != nil {
 		log.Fatalf("Error Query using loki logcli: %s", err)
 	}

--- a/loadclient/runner.go
+++ b/loadclient/runner.go
@@ -74,6 +74,8 @@ func ExecuteMultiThreaded(options Options) {
 				q := logQuerier{}
 				// initialize the list of queries
 				q.initQueries()
+				// initialize the range
+				q.initQueryRange()
 				// define Destination for queries
 				q.initQueryDestination()
 				// define the runner action

--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "error", "Log level: debug, info, warning, error (default = error)")
 
 	rootCmd.PersistentFlags().StringArrayVar(&opt.Queries, "queries", []string{}, "list of queries e.g. {client=\"promtail\"} (default = none)")
+	rootCmd.PersistentFlags().StringVar(&opt.QueryRange, "query-range", "1m", "The interval of time that logs were recorded in should be collected for")
 	rootCmd.PersistentFlags().StringVar(&opt.QueryFile, "query-file", "", "Query file name (default = none)")
 
 	rootCmd.AddCommand(generateCmd)


### PR DESCRIPTION
Reverts the batch change #14, which turned out to be unneeded and allows for the configuration of the query duration so that it is not always 24 hours