### PR TITLE
Adding bearer token to promtail configuration

### DIFF
--- a/loadclient/config.go
+++ b/loadclient/config.go
@@ -16,6 +16,7 @@ type Options struct {
 	QueryRange           string
 	Loki                 Loki
 	DisableSecurityCheck bool
+	BearerTokenFile      string
 }
 
 type Loki struct {

--- a/loadclient/generate.go
+++ b/loadclient/generate.go
@@ -214,7 +214,7 @@ func (g *logGenerator) initGenerateDestination() func() {
 		}
 		g.writeToDestination = g.destinationFile
 	case "loki":
-		g.promtailClient, err = initPromtailClient(opt.DestinationAPIURL, opt.Loki.TenantID, opt.DisableSecurityCheck)
+		g.promtailClient, err = initPromtailClient(opt.DestinationAPIURL, opt.Loki.TenantID, opt.BearerTokenFile, opt.DisableSecurityCheck)
 		if err != nil {
 			log.Fatalf("Unable to initialize promtail client %v", err)
 		}
@@ -274,14 +274,16 @@ func GenerateLog(options Options) {
 	ExecuteMultiThreaded(options)
 }
 
-func initPromtailClient(apiURL string, tenantID string, disableSecurityCheck bool) (promtail.Client, error) {
+func initPromtailClient(apiURL, tenantID, credFile string, disableSecurityCheck bool) (promtail.Client, error) {
 	URL, err := url.Parse(apiURL)
 	if err != nil {
 		return nil, err
 	}
 	logger := kitlog.NewLogfmtLogger(os.Stdout)
+
 	promtailClient, err := promtail.New(promtail.Config{
 		Client: config.HTTPClientConfig{
+			BearerTokenFile: credFile,
 			TLSConfig: config.TLSConfig{
 				InsecureSkipVerify: disableSecurityCheck,
 			},

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&opt.Destination, "destination", "stdout", "Log Destination: loki, elasticsearch, stdout, file. (default stdout)")
 	rootCmd.PersistentFlags().Int64Var(&opt.TotalLogLines, "totalLogLines", 0, "Total number of log lines per thread (default 0 - infinite)")
 	rootCmd.PersistentFlags().BoolVar(&opt.DisableSecurityCheck, "disable-security-check", false, "Disable security check in HTTPS client. (default false)")
+	rootCmd.PersistentFlags().StringVar(&opt.BearerTokenFile, "loki-bearer-token-file", "/var/run/secrets/kubernetes.io/serviceaccount/token", "Path to file containing bearer token")
 
 	rootCmd.PersistentFlags().StringVar(&opt.LogFormat, "output-format", "default", "The output format: default, crio (mimic CRIO output), csv, json")
 	rootCmd.PersistentFlags().IntVar(&opt.SyntheticPayloadSize, "synthetic-payload-size", 100, "Payload length [int] (default = 100)")


### PR DESCRIPTION
This PR adds a bearer token to the Promtail configuration to communicate to the Loki Operator's gateway component.