### PR TITLE
Fix formatting of severity for csv output type

### DIFF
--- a/loadclient/generate.go
+++ b/loadclient/generate.go
@@ -156,7 +156,7 @@ func formatCrio(hash string, messageCount int64, payload string) string {
 
 func formatCSV(hash string, messageCount int64, payload string) string {
 	now := time.Now().Format(time.RFC3339Nano)
-	return fmt.Sprintf("ts=%s stream=%s host=%s lvl=%s count=%d msg=%s\n", now, randStream(), hash, randLevel(), messageCount, payload)
+	return fmt.Sprintf("ts=%s stream=%s host=%s level=%s count=%d msg=%q\n", now, randStream(), hash, randLevel(), messageCount, payload)
 }
 
 func formatJson(hash string, messageCount int64, payload string) string {


### PR DESCRIPTION
We seem to be using `level` instead of `lvl` in our data model and it seems Loki does the same. I also noticed that the `msg` is split into multiple words when using the `logfmt` filter in Loki because the message is not quoted and modified this as well.